### PR TITLE
Add admin-only Filament dashboard widgets for student & GPA statistics

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Pages\Page;
+
+class Dashboard extends \Filament\Pages\Dashboard
+{
+    protected static string $routePath = '/dashboard';
+}

--- a/app/Filament/Widgets/StudentGpaStatsWidget.php
+++ b/app/Filament/Widgets/StudentGpaStatsWidget.php
@@ -26,9 +26,9 @@ class StudentGpaStatsWidget extends StatsOverviewWidget
         $avgGpa = $studentsQuery->avg('gpa');
 
         return [
-            Stat::make('Min GPA', $this->formatGpa($minGpa)),
-            Stat::make('Avg GPA', $this->formatGpa($avgGpa)),
-            Stat::make('Max GPA', $this->formatGpa($maxGpa)),
+            Stat::make('أقل معدل', $this->formatGpa($minGpa)),
+            Stat::make('متوسط المعدلات', $this->formatGpa($avgGpa)),
+            Stat::make('أقصى معدل', $this->formatGpa($maxGpa)),
         ];
     }
 

--- a/app/Filament/Widgets/StudentRegistrationStatsWidget.php
+++ b/app/Filament/Widgets/StudentRegistrationStatsWidget.php
@@ -34,9 +34,9 @@ class StudentRegistrationStatsWidget extends StatsOverviewWidget
         $studentsWithoutRequests = max($studentCount - $studentsWithRequests, 0);
 
         return [
-            Stat::make('Students', $studentCount),
-            Stat::make('Requests Created', $studentsWithRequests),
-            Stat::make('Requests Missing', $studentsWithoutRequests),
+            Stat::make('الطلاب', $studentCount),
+            Stat::make('طلبات التسجيل', $studentsWithRequests),
+            Stat::make('الطلاب الذين لم يقوموا بإنشاء طلب تسجيل', $studentsWithoutRequests),
         ];
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Pages\Dashboard;
 use App\Filament\Widgets\StudentGpaStatsWidget;
 use App\Filament\Widgets\StudentRegistrationStatsWidget;
 use Althinect\FilamentSpatieRolesPermissions\FilamentSpatieRolesPermissionsPlugin;
@@ -51,11 +52,11 @@ class AdminPanelProvider extends PanelProvider
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([
-                // Pages\Dashboard::class,
+                 Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([
-                AccountWidget::class,
+//                AccountWidget::class,
                 StudentRegistrationStatsWidget::class,
                 StudentGpaStatsWidget::class,
                 // Widgets\FilamentInfoWidget::class,

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,7 @@ Route::get('/', function () {
     }
 
     if ($user->hasRole('admin')) {
-        return redirect(\App\Filament\Resources\MajorResource::getUrl());
+        return redirect(\App\Filament\Pages\Dashboard::getUrl());
     }
 
     if ($user->registrationRequests()->exists()) {


### PR DESCRIPTION
### Motivation

- Provide admin-only dashboard widgets that summarize student counts and registration request coverage.
- Surface useful GPA metrics (min / avg / max) for students in the Filament admin dashboard.
- Keep stats scoped to non-admin users so administrators are excluded from student metrics.

### Description

- Added two Filament `StatsOverviewWidget` classes: `app/Filament/Widgets/StudentRegistrationStatsWidget.php` and `app/Filament/Widgets/StudentGpaStatsWidget.php` which compute counts and GPA stats respectively.
- Each widget implements `canView()` to restrict visibility to users with the `admin` role via `auth()->user()->hasRole('admin')`.
- `StudentRegistrationStatsWidget` counts total students (excluding admin roles), number of distinct students who created `RegistrationRequest` records, and computes missing requests.
- Registered the new widgets in the admin panel provider by adding them to the `->widgets([...])` list in `app/Providers/Filament/AdminPanelProvider.php`.

### Testing

- Ran `vendor/bin/pint --dirty` to format code, but it failed because `vendor` is not installed in the environment so formatting could not be executed.
- No other automated tests were run in this environment due to missing dependencies (`vendor`); unit/feature tests and `php artisan` commands were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637ffbbda4832d8ae3515951450f9b)