### PR TITLE
Fix Livewire file uploads behind Coolify reverse proxy

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        // Trust all proxies (required for Coolify/reverse proxy setups)
+        // This ensures Livewire signed URLs use the correct scheme/host
+        $middleware->trustProxies(at: '*');
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
Configure TrustProxies middleware to trust all proxies. This is required when running behind Coolify's reverse proxy (Traefik/Caddy) because:

1. SSL terminates at Coolify's proxy, so the app sees HTTP
2. Livewire uses signed URLs for file uploads
3. Without trusting proxy headers, signed URLs have wrong scheme/host
4. This causes signature verification to fail on upload requests