### PR TITLE
Fix pivot model primary key for MajorRegistrationRequest

### DIFF
--- a/app/Models/MajorRegistrationRequest.php
+++ b/app/Models/MajorRegistrationRequest.php
@@ -11,6 +11,8 @@ class MajorRegistrationRequest extends Pivot
 {
     use LogsActivity;
 
+    public $incrementing = true;
+
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()->logAll();


### PR DESCRIPTION
The MajorRegistrationRequest pivot table has an auto-incrementing id column, but the Pivot model class doesn't expect this by default. Added $incrementing = true to fix the empty column name query error.