### PR TITLE
Migrate notifications column from text to JSON

### DIFF
--- a/database/migrations/2026_01_14_073300_change_notifications_data_column_to_json.php
+++ b/database/migrations/2026_01_14_073300_change_notifications_data_column_to_json.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->json('data')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->text('data')->change();
+        });
+    }
+};


### PR DESCRIPTION
This migration changes the data column in the notifications table from text to json type to properly support structured notification data storage.