### PR TITLE
Fix undefined relationship error in Major model

### DIFF
--- a/app/Filament/Resources/MajorResource/Pages/ListMajors.php
+++ b/app/Filament/Resources/MajorResource/Pages/ListMajors.php
@@ -22,7 +22,8 @@ class ListMajors extends ListRecords
             CreateAction::make(),
             ExportAction::make()
                 ->exporter(UserExporter::class)
-                ->label('تصدير الطلاب'),
+                ->label('تصدير الطلاب')
+                ->modifyQueryUsing(fn () => User::query()),
             Action::make('distribute')
                 ->label('توزيع الطلاب على المسارات')
                 ->action(function () {


### PR DESCRIPTION
The ExportAction in ListMajors was using UserExporter but querying Major models. This caused a RelationNotFoundException when trying to access the 'major' relationship on Major models (which don't have that relationship).

Fixed by adding modifyQueryUsing to explicitly query User models, allowing the UserExporter to correctly access the User->major relationship.