### PR TITLE
Style student import/export actions and fix modal titles

### DIFF
--- a/app/Filament/Resources/MajorResource/Pages/ListMajors.php
+++ b/app/Filament/Resources/MajorResource/Pages/ListMajors.php
@@ -23,7 +23,10 @@ class ListMajors extends ListRecords
             ExportAction::make()
                 ->exporter(UserExporter::class)
                 ->label('تصدير الطلاب')
-                ->modifyQueryUsing(fn () => User::query()->whereDoesntHave('roles')->orderBy('major_id')),
+                ->modalHeading('تصدير الطلاب')
+                ->modifyQueryUsing(fn () => User::query()->whereDoesntHave('roles')->orderBy('major_id'))
+                ->icon('heroicon-o-arrow-down-tray')
+                ->color('info'),
             Action::make('distribute')
                 ->label('توزيع الطلاب على المسارات')
                 ->action(function () {
@@ -69,7 +72,9 @@ class ListMajors extends ListRecords
                         ->title('تم توزيع الطلاب على المسارات')
                         ->success()
                         ->send();
-                }),
+                })
+                ->icon('heroicon-o-arrows-right-left')
+                ->color('primary'),
         ];
     }
 }

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -35,6 +35,7 @@ class ListUsers extends ListRecords
             ImportAction::make()
                 ->label('استيراد الطلاب')
                 ->importer(UserImporter::class)
+                ->modalHeading('استيراد الطلاب')
                 ->icon('heroicon-o-arrow-up-tray')
                 ->color('success'),
         ];


### PR DESCRIPTION
### Motivation
- Make the student import/export and distribution header actions visually consistent with other actions by adding icons, colors, and correct Arabic modal headings.

### Description
- Added `->modalHeading('استيراد الطلاب')` to the import action in `app/Filament/Resources/UserResource/Pages/ListUsers.php` to fix the import modal title.
- Added `->modalHeading('تصدير الطلاب')`, `->icon('heroicon-o-arrow-down-tray')`, and `->color('info')` to the export action in `app/Filament/Resources/MajorResource/Pages/ListMajors.php` to fix the export modal title and style the action.
- Added `->icon('heroicon-o-arrows-right-left')` and `->color('primary')` to the distribute action in `app/Filament/Resources/MajorResource/Pages/ListMajors.php` to match other header action styling.
- Changes were committed with message: `Adjust student import/export actions`.

### Testing
- Attempted to run `vendor/bin/pint --dirty` but `vendor/bin/pint` was not available in the environment; no automated tests were run.
- Local static checks and Filament runtime were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69677211eac0832dbeb58905023ddce7)